### PR TITLE
Update Sharee version 

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
@@ -39,7 +39,7 @@ import elemental.json.JsonObject;
  * 
  * @author Paola De Bartolo / Flowing Code
  */
-@NpmPackage(value = "sharee", version = "1.1.13")
+@NpmPackage(value = "sharee", version = "1.1.20")
 @JsModule("./src/fc-sharee-connector.js")
 @CssImport("./styles/fc-share-easy/style.css")
 class BaseShareEasy<T extends BaseShareEasy<T>> {

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/DropdownShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/DropdownShareEasy.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/FixedShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/FixedShareEasy.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/FixedShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/FixedShareEasy.java
@@ -19,8 +19,6 @@
  */
 package com.flowingcode.vaadin.addons.shareeasy;
 
-import java.util.stream.Stream;
-import com.flowingcode.vaadin.addons.shareeasy.enums.Driver;
 import com.flowingcode.vaadin.addons.shareeasy.enums.Mode;
 import com.flowingcode.vaadin.addons.shareeasy.enums.Position;
 import elemental.json.Json;
@@ -36,10 +34,7 @@ public class FixedShareEasy extends BaseShareEasy<FixedShareEasy> {
   public boolean noTitle = false;
 
   public static FixedShareEasy create() {
-    // remove copy driver cause is not working https://github.com/parsagholipour/sharee/issues/4
-    Driver[] fixedDrivers =
-        Stream.of(Driver.values()).filter(d -> Driver.COPY != d).toArray(Driver[]::new);
-    return new FixedShareEasy().withDrivers(fixedDrivers);
+    return new FixedShareEasy();
   }
 
   public FixedShareEasy withPosition(Position position) {

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/HoverShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/HoverShareEasy.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/NormalShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/NormalShareEasy.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyDriver.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyDriver.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/TextShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/TextShareEasy.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Animation.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Animation.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Direction.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Direction.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Driver.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Driver.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Locale.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Locale.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Mode.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Mode.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Position.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Position.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Type.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Type.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/util/CustomDriverOptions.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/util/CustomDriverOptions.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/util/LanguageKeys.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/util/LanguageKeys.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/util/Options.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/util/Options.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/VAADIN/package.properties
+++ b/src/main/resources/META-INF/VAADIN/package.properties
@@ -1,1 +1,20 @@
+###
+# #%L
+# Share Easy Add-on
+# %%
+# Copyright (C) 2023 - 2025 Flowing Code
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 vaadin.allowed-packages=com.flowingcode

--- a/src/main/resources/META-INF/resources/frontend/src/fc-sharee-connector.js
+++ b/src/main/resources/META-INF/resources/frontend/src/fc-sharee-connector.js
@@ -22,14 +22,12 @@ import Sharee from 'sharee';
 window.fcShareeConnector = {
 
 	create: function (container, optionsJson) {
-		this._updateSocialShareLinks();
 		this._updateCopyDriverOnClick();
 		let parsedOptions = JSON.parse(optionsJson);
 		const sharee = new Sharee(container, parsedOptions);
 	},
 
 	createWithCustomDrivers: function (container, optionsJson) {
-		this._updateSocialShareLinks();
 		this._updateCopyDriverOnClick();
 		let parsedOptions = JSON.parse(optionsJson);
 		// add the custom drivers to the list of drivers
@@ -87,26 +85,7 @@ window.fcShareeConnector = {
 
 		Sharee.addDriver(name, f);
 	},	
-
-	/*
-	 * Workaround because of issue https://github.com/parsagholipour/sharee/issues/2
-	 * (to be removed when issue is fixed)
-	 */
-	_updateSocialShareLinks() {
-		Sharee.drivers['facebook'].prototype.getLink = function () {
-			return `https://facebook.com/sharer/sharer.php?u=${encodeURIComponent(this.options?.shareLink)}&t=${encodeURIComponent(this.options?.shareText)}`
-		}
-		Sharee.drivers['whatsapp'].prototype.getLink = function () {
-			return `https://wa.me?text=${encodeURIComponent(this.options?.shareText)} \n ${encodeURIComponent(this.options?.shareLink)}`
-		}
-		Sharee.drivers['twitter'].prototype.getLink = function () {
-			return `https://twitter.com/intent/tweet?text=${encodeURIComponent(this.options?.shareText)}&url=${encodeURIComponent(this.options?.shareLink)}`
-		}
-		Sharee.drivers['linkedin'].prototype.getLink = function () {
-			return `https://www.linkedin.com/shareArticle?url=${encodeURIComponent(this.options?.shareLink)}`
-		}
-	},
-
+	
 	/**
 	 * Replaces onClick function on CopyDriver to take in consideration shareLink option 
 	 * if exists. (Fixes https://github.com/FlowingCode/ShareEasy/issues/8) 

--- a/src/main/resources/META-INF/resources/frontend/src/fc-sharee-connector.js
+++ b/src/main/resources/META-INF/resources/frontend/src/fc-sharee-connector.js
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/DemoLayout.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasyDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasyDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/DefaultValuesDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/DefaultValuesDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/DemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/DemoView.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/DropdownModeDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/DropdownModeDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/FixedModeDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/FixedModeDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/HoverModeDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/HoverModeDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/NewTwitterDriverOptions.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/NewTwitterDriverOptions.java
@@ -2,14 +2,14 @@
 * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/NormalModeDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/NormalModeDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyDemoView.java
@@ -2,14 +2,14 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/SpecialCustomizationsDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/SpecialCustomizationsDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/TextModeDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/TextModeDemo.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/TrelloDriverOptions.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/TrelloDriverOptions.java
@@ -2,14 +2,14 @@
 * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/AbstractViewTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/AbstractViewTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/BaseShareEasyIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/BaseShareEasyIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyDefaultValuesIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyDefaultValuesIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyElement.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyFixedModeIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyFixedModeIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyNormalModeIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyNormalModeIT.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/test/SerializationTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/test/SerializationTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/frontend/styles/share-easy-demo-styles.css
+++ b/src/test/resources/META-INF/frontend/styles/share-easy-demo-styles.css
@@ -2,7 +2,7 @@
  * #%L
  * Share Easy Add-on
  * %%
- * Copyright (C) 2023 - 2024 Flowing Code
+ * Copyright (C) 2023 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR includes a version update of the base component Sharee, to the latest available version 1.1.20. This version includes fixes we requested some time ago. Code including workarounds for those issues has been removed.

Also, license headers were updated.

Close #14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year range in all source, resource, and test files to "2023 - 2025".
  * Added a license header to the package properties file.
  * Upgraded the version of a third-party package dependency.
* **Refactor**
  * Simplified the creation logic for a fixed sharing component.
  * Removed an internal workaround for social share links in the connector script.
* **Style**
  * Made minor whitespace and formatting adjustments in license headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->