### PR TITLE
refactor: update sharee version to 1.1.24

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
@@ -39,7 +39,7 @@ import elemental.json.JsonObject;
  * 
  * @author Paola De Bartolo / Flowing Code
  */
-@NpmPackage(value = "sharee", version = "1.1.23")
+@NpmPackage(value = "sharee", version = "1.1.24")
 @JsModule("./src/fc-sharee-connector.js")
 @CssImport("./styles/fc-share-easy/style.css")
 class BaseShareEasy<T extends BaseShareEasy<T>> {


### PR DESCRIPTION
Close #18

This new version of the base component, 1.1.24, includes the fix for the encoding missing in the links. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the version of an internal package dependency to ensure compatibility and access to the latest improvements. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->