### PR TITLE
feat: add listener for share actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This component is a wrapper of [Sharee](https://github.com/parsagholipour/sharee
 - Default social media drivers to share links easily: Copy, Twitter, Facebook, Linkedin, Whatsapp, Telegram.
 - Modes to display the Easy Share menu: Fixed, Normal, Hover, Text, Dropdown.
 - By defaut, locale and keys are in English but custom locales and keys can be defined.
+- Listen to share actions to track which driver was clicked.
 
 ## Supported versions
 
@@ -111,6 +112,20 @@ FixedShareEasy.create().forComponent(this);
 /* Normal mode */
 Div div = new Div();
 NormalShareEasy.create().withNoTitle(true).forComponent(div);
+add(div);
+```
+
+## Listening to share actions
+
+Register a listener to be notified when one of the share drivers is clicked. The event exposes the
+clicked driver (both as the raw name and, for default drivers, as a `Driver` enum value) and the
+share link:
+
+```java
+Div div = new Div();
+NormalShareEasy.create()
+    .withShareListener(event -> Notification.show("Shared via " + event.getDriverName()))
+    .forComponent(div);
 add(div);
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.vaadin.addons.flowingcode</groupId>
 	<artifactId>share-easy-addon</artifactId>
-	<version>2.1.1-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<name>Share Easy Add-on</name>
 	<description>Share Eady Add-on for Vaadin Flow</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+            <groupId>com.flowingcode.vaadin</groupId>
+            <artifactId>json-migration-helper</artifactId>
+            <version>0.9.3</version>
+        </dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
@@ -156,6 +161,12 @@
 			<artifactId>gwt-elemental</artifactId>
 			<version>2.8.2.vaadin2</version>
 			<scope>compile</scope>
+		</dependency>		 
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.34</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-            <version>5.1.1</version>
+            <version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/BaseShareEasy.java
@@ -21,16 +21,22 @@ package com.flowingcode.vaadin.addons.shareeasy;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import com.flowingcode.vaadin.addons.shareeasy.enums.Driver;
 import com.flowingcode.vaadin.addons.shareeasy.enums.Locale;
 import com.flowingcode.vaadin.addons.shareeasy.util.CustomDriverOptions;
 import com.flowingcode.vaadin.addons.shareeasy.util.LanguageKeys;
 import com.flowingcode.vaadin.addons.shareeasy.util.Options;
+import com.flowingcode.vaadin.jsonmigration.JsonMigration;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.shared.Registration;
+
 import elemental.json.JsonObject;
+import elemental.json.JsonString;
+import lombok.experimental.ExtensionMethod;
 
 /**
  * BaseSharee represents the base class for creating Sharee instances.
@@ -42,6 +48,7 @@ import elemental.json.JsonObject;
 @NpmPackage(value = "sharee", version = "1.1.24")
 @JsModule("./src/fc-sharee-connector.js")
 @CssImport("./styles/fc-share-easy/style.css")
+@ExtensionMethod(value = JsonMigration.class, suppressBaseMethods = true)
 class BaseShareEasy<T extends BaseShareEasy<T>> {
 
   private Component component;
@@ -49,8 +56,12 @@ class BaseShareEasy<T extends BaseShareEasy<T>> {
   private Options options = new Options();
 
   Map<String, CustomDriverOptions> customDrivers = new HashMap<>();
-  
+
   protected boolean withDefaultDriversListFirst = true;
+
+  private ShareEasyClickListener shareListener;
+
+  private Registration shareListenerRegistration;
 
   /**
    * Sets the share link for the shared content.
@@ -122,6 +133,17 @@ class BaseShareEasy<T extends BaseShareEasy<T>> {
   }
 
   /**
+   * Sets the listener that is notified when one of the share drivers is clicked.
+   *
+   * @param shareListener the listener to notify on driver clicks
+   * @return The current instance of the BaseSharee class
+   */
+  public T withShareListener(ShareEasyClickListener shareListener) {
+    this.shareListener = shareListener;
+    return (T) this;
+  }
+
+  /**
    * Initializes the Sharee component with the specified Vaadin component.
    *
    * @param component The Vaadin component to associate with the Sharee instance
@@ -141,6 +163,7 @@ class BaseShareEasy<T extends BaseShareEasy<T>> {
   }
 
   private void createSharee() {
+    registerShareListener();
     String shareeOptions = getJsonObjectOptions().toJson();
     if(customDrivers.isEmpty()) {
       this.create(shareeOptions);
@@ -160,6 +183,26 @@ class BaseShareEasy<T extends BaseShareEasy<T>> {
   
   private void create(String shareeOptions) {
     component.getElement().executeJs("fcShareeConnector.create(this, $0)", shareeOptions);
+  }
+
+  private void registerShareListener() {
+    if (shareListenerRegistration != null) {
+      shareListenerRegistration.remove();
+      shareListenerRegistration = null;
+    }
+    if (shareListener == null) {
+      return;
+    }
+    shareListenerRegistration = component.getElement().addEventListener("driver-clicked", event -> {
+      JsonObject detail = event.getEventData();
+      String driverName = getStringOrNull(detail, "event.detail.name");
+      String link = getStringOrNull(detail, "event.detail.link");
+      shareListener.onShare(new ShareEasyClickEvent(component, driverName, link));
+    }).addEventData("event.detail.name").addEventData("event.detail.link");
+  }
+
+  private static String getStringOrNull(JsonObject data, String key) {
+    return data.hasKey(key) && data.get(key) instanceof JsonString ? data.getString(key) : null;
   }
 
   /**

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyClickEvent.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyClickEvent.java
@@ -1,0 +1,93 @@
+/*-
+ * #%L
+ * Share Easy Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.shareeasy;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+import com.flowingcode.vaadin.addons.shareeasy.enums.Driver;
+import com.vaadin.flow.component.Component;
+
+/**
+ * Event fired when one of the share drivers is clicked.
+ *
+ * @author Paola De Bartolo / Flowing Code
+ */
+@SuppressWarnings("serial")
+public class ShareEasyClickEvent implements Serializable {
+
+  private final Component source;
+
+  private final String driverName;
+
+  private final String link;
+
+  /**
+   * Creates a new share click event.
+   *
+   * @param source the component the Share Easy instance is attached to
+   * @param driverName the name of the clicked driver, e.g. "telegram"
+   * @param link the share link associated with the driver (the copied URL for the copy driver); may
+   *        be {@code null} for custom drivers without a link
+   */
+  public ShareEasyClickEvent(Component source, String driverName, String link) {
+    this.source = Objects.requireNonNull(source, "source must not be null");
+    this.driverName = Objects.requireNonNull(driverName, "driverName must not be null");
+    this.link = link;
+  }
+
+  /**
+   * Gets the component the Share Easy instance is attached to.
+   *
+   * @return the source component
+   */
+  public Component getSource() {
+    return source;
+  }
+
+  /**
+   * Gets the name of the clicked driver.
+   *
+   * @return the driver name, e.g. "telegram"
+   */
+  public String getDriverName() {
+    return driverName;
+  }
+
+  /**
+   * Gets the clicked driver as a {@link Driver default driver}, if it corresponds to one.
+   *
+   * @return the matching default {@link Driver}, or an empty {@link Optional} if the clicked driver
+   *         is a custom driver
+   */
+  public Optional<Driver> getDriver() {
+    return Driver.fromName(driverName);
+  }
+
+  /**
+   * Gets the share link associated with the clicked driver. For the copy driver this is the URL that
+   * was copied to the clipboard.
+   *
+   * @return the share link, or {@code null} for custom drivers without a link
+   */
+  public String getLink() {
+    return link;
+  }
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyClickListener.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/ShareEasyClickListener.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * Share Easy Add-on
+ * %%
+ * Copyright (C) 2023 - 2026 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.shareeasy;
+
+import com.vaadin.flow.function.SerializableConsumer;
+
+/**
+ * Listener notified when one of the share drivers is clicked.
+ *
+ * @author Paola De Bartolo / Flowing Code
+ */
+@FunctionalInterface
+public interface ShareEasyClickListener extends SerializableConsumer<ShareEasyClickEvent> {
+
+  /**
+   * Invoked when a share driver is clicked.
+   *
+   * @param event the share click event
+   */
+  void onShare(ShareEasyClickEvent event);
+
+  @Override
+  default void accept(ShareEasyClickEvent event) {
+    onShare(event);
+  }
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Driver.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/shareeasy/enums/Driver.java
@@ -19,6 +19,7 @@
  */
 package com.flowingcode.vaadin.addons.shareeasy.enums;
 
+import java.util.Optional;
 import com.flowingcode.vaadin.addons.shareeasy.ShareEasyDriver;
 
 /**
@@ -39,5 +40,22 @@ public enum Driver implements ShareEasyDriver {
   @Override
   public String getName() {
     return name;
+  }
+
+  /**
+   * Resolves a default driver from its name (the name carried by the share event), if it matches one
+   * of the default drivers.
+   *
+   * @param name the driver name, e.g. "telegram"
+   * @return the matching {@link Driver}, or an empty {@link Optional} if the name does not correspond
+   *         to a default driver (for instance, a custom driver)
+   */
+  public static Optional<Driver> fromName(String name) {
+    for (Driver driver : values()) {
+      if (driver.name.equals(name)) {
+        return Optional.of(driver);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/src/main/resources/META-INF/resources/frontend/src/fc-sharee-connector.js
+++ b/src/main/resources/META-INF/resources/frontend/src/fc-sharee-connector.js
@@ -24,6 +24,7 @@ window.fcShareeConnector = {
 	create: function (container, optionsJson) {
         this._updateXButtonLabel();
 		this._updateCopyDriverOnClick();
+		this._patchDriverNames();
 		let parsedOptions = JSON.parse(optionsJson);
 		const sharee = new Sharee(container, parsedOptions);
 	},
@@ -31,6 +32,7 @@ window.fcShareeConnector = {
 	createWithCustomDrivers: function (container, optionsJson) {
         this._updateXButtonLabel();
 		this._updateCopyDriverOnClick();
+		this._patchDriverNames();
 		let parsedOptions = JSON.parse(optionsJson);
 		// add the custom drivers to the list of drivers
 		let drivers = parsedOptions.drivers.concat(container.customDrivers);
@@ -95,6 +97,26 @@ window.fcShareeConnector = {
 	 */
 	_updateCopyDriverOnClick() {
 		Sharee.drivers['copy'].prototype.onClick = function(e) {
+			// The copy driver copies a URL instead of navigating, so the shared
+			// "link" is the text that gets copied (the base CopyDriver's getLink()
+			// is undefined). Dispatch the same "driver-clicked" event the base
+			// driver emits via super.onClick (lost when onClick is fully replaced
+			// here), carrying the actual copied URL.
+			const copyText = this.options?.shareLink || window.location.href
+			const event = new CustomEvent('driver-clicked', {
+				detail: {
+					name: this.getName(),
+					link: copyText,
+					originalEvent: e,
+				},
+				bubbles: true,
+				composed: true,
+			});
+			this.options?.targetElement.dispatchEvent(event);
+			// Honor preventDefault as the base CopyDriver does after super.onClick.
+			if (e.defaultPrevented) {
+			  return
+			}
 		    const successText = this.lang['CopiedSuccessfully']
 		    const el = e.currentTarget;
 		    const textEl = el.querySelector('div:nth-child(2)')
@@ -102,7 +124,6 @@ window.fcShareeConnector = {
 		      textEl.innerHTML = this.getButtonText()
 		      return
 		    }
-		    let copyText = this.options?.shareLink || window.location.href
 		    navigator.clipboard.writeText(copyText).then(() => {
 		      textEl.innerHTML = successText
 		      textEl.style.transition = '300ms all'
@@ -125,5 +146,20 @@ window.fcShareeConnector = {
         Sharee.drivers['x'].prototype.getButtonText = function () {
             return "X";
         }
-    }
+    },
+
+	/**
+	 * Overrides getName on each default driver so that it returns the driver's
+	 * registered key (e.g. "telegram", "copy") instead of the bundled (and
+	 * unstable) class name. This makes the name carried by the "driver-clicked"
+	 * event reliable on the server side. Custom drivers already define their own
+	 * getName in _addDriver, so they are not affected.
+	 */
+	_patchDriverNames() {
+		Object.keys(Sharee.drivers).forEach(function (name) {
+			Sharee.drivers[name].prototype.getName = function () {
+				return name;
+			};
+		});
+	}
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/NormalModeDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/NormalModeDemo.java
@@ -27,6 +27,7 @@ import com.flowingcode.vaadin.addons.shareeasy.enums.Driver;
 import com.flowingcode.vaadin.addons.shareeasy.util.CustomDriverOptions;
 import com.flowingcode.vaadin.addons.shareeasy.util.LanguageKeys;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 
@@ -127,11 +128,25 @@ public class NormalModeDemo extends BaseShareEasyDemo {
     customDrivers.put("Trello", new TrelloDriverOptions());
     NormalShareEasy.create().withCustomDrivers(customDrivers).forComponent(normalDiv7);
     // #if vaadin eq 0
-    Div example7 = createContainerDiv("With custom driver for extra social: Trello", normalDiv7); 
+    Div example7 = createContainerDiv("With custom driver for extra social: Trello", normalDiv7);
     SourceCodeViewer.highlightOnHover(example7, "example7");
     add(example7);
+    addSeparator();
     // #endif
     // show-source add(normalDiv7);
+    // end-block
+
+    // begin-block example8
+    Div normalDiv8 = new Div();
+    NormalShareEasy.create()
+        .withShareListener(event -> Notification.show("Shared via " + event.getDriverName()))
+        .forComponent(normalDiv8);
+    // #if vaadin eq 0
+    Div example8 = createContainerDiv("With share listener", normalDiv8);
+    SourceCodeViewer.highlightOnHover(example8, "example8");
+    add(example8);
+    // #endif
+    // show-source add(normalDiv8);
     // end-block
   }
 

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyElement.java
@@ -30,27 +30,32 @@ public class ShareEasyElement extends DivElement {
   }
 
   public boolean copyExists() {
-    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__F").exists();
+    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__copy").exists();
   }
 
   public boolean telegramExists() {
-    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__I").exists();
+    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__telegram")
+        .exists();
   }
 
   public boolean facebookExists() {
-    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__G").exists();
+    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__facebook")
+        .exists();
   }
 
   public boolean whatsappExists() {
-    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__P").exists();
+    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__whatsapp")
+        .exists();
   }
 
   public boolean twitterExists() {
-    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__W").exists();
+    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__twitter")
+        .exists();
   }
 
   public boolean linkedinExists() {
-    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__A").exists();
+    return this.$(AnchorElement.class).attributeContains("class", "sharee__driver__linkedin")
+        .exists();
   }
 
   public boolean normalModeContainAllDefaultValues() {

--- a/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyNormalModeIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/shareeasy/it/ShareEasyNormalModeIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import com.vaadin.flow.component.html.testbench.AnchorElement;
+import com.vaadin.flow.component.notification.testbench.NotificationElement;
 
 public class ShareEasyNormalModeIT extends BaseShareEasyIT {
 
@@ -71,5 +72,21 @@ public class ShareEasyNormalModeIT extends BaseShareEasyIT {
     int driversCount = normalWithExtraSocial.getAllDriversAnchors().size();
     assertTrue("Normal Share Easy shows no extra social",
         driversCount == DEFAULT_NORMAL_DRIVER_COUNT + 1);
+  }
+
+  @Test
+  public void withShareListener_clickDriver_firesEvent() {
+    // The Sharee instances are created asynchronously via executeJs, so wait until the
+    // share-listener example (the 8th normal share) has rendered before interacting.
+    waitUntil(driver -> $(ShareEasyElement.class).attributeContains("class", "sharee__normal").all()
+        .size() > 7);
+    ShareEasyElement normalWithShareListener =
+        $(ShareEasyElement.class).attributeContains("class", "sharee__normal").get(7);
+    AnchorElement copyDriver = normalWithShareListener.$(AnchorElement.class)
+        .attributeContains("class", "sharee__driver__copy").waitForFirst();
+    copyDriver.click();
+    NotificationElement notification = $(NotificationElement.class).waitForFirst();
+    assertTrue("Share listener was not notified with the clicked driver name",
+        notification.getText().contains("copy"));
   }
 }


### PR DESCRIPTION
## Description
Adds the ability to listen for share actions, as requested in #12.

A new `withShareListener(ShareEasyClickListener)` builder method registers a
listener that is notified whenever a share driver is clicked. The
`ShareEasyClickEvent` exposes:
- `getDriverName()` - the clicked driver's name (e.g. `"telegram"`)
- `getDriver()` - the resolved `Driver` for default drivers (`Optional`)
- `getLink()` - the share link (the copied URL for the copy driver)
- `getSource()` - the component the Share Easy instance is attached to

### How it works
This builds on the upstream `driver-clicked` event added in sharee 1.1.24
(parsagholipour/sharee#6). The connector:
- patches each default driver's `getName` so the event carries a stable
  driver key instead of the bundled (build-dependent) class name;
- re-dispatches the event for the copy driver - whose `onClick` is fully
  overridden by the add-on - carrying the actual copied URL.

## Additional changes
- `build`: bump `webdrivermanager` to 5.9.2 so the integration tests can
  resolve a driver for current Chrome versions.
- `build`: set version to 2.2.0-SNAPSHOT.

## Testing
- New integration test `ShareEasyNormalModeIT.withShareListener_clickDriver_firesEvent`.
- New demo example ("With share listener") in the Normal mode demo.

Close #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added share-driver click listening with a new click event (includes clicked driver name and optional share link).
  * Added a fluent callback registration to react when a driver is clicked.
* **Behavior**
  * Driver names are normalized so emitted events match the registered driver keys.
  * Copy now dispatches the click event early, and stops further handling if the event was prevented.
* **Documentation**
  * Developer Guide adds “Listening to share actions” with a Java example; README lists the new driver-click tracking capability.
* **Tests / Demos**
  * Added a demo and integration test verifying the listener fires and includes `"copy"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->